### PR TITLE
Version bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 
 [dependencies]
 embedded-graphics = "0.8.1"
-bitflags = "1.3.2"
+bitflags = "2.4.0"
 
 [dev-dependencies]
 chrono = "0.4.31"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ exclude = [
 ]
 
 [dependencies]
-embedded-graphics = "0.7.1"
+embedded-graphics = "0.8.1"
 bitflags = "1.3.2"
 
 [dev-dependencies]
-chrono = "0.4.19"
-embedded-graphics-simulator = "0.3.0"
+chrono = "0.4.31"
+embedded-graphics-simulator = "0.5.0"

--- a/src/segments.rs
+++ b/src/segments.rs
@@ -69,6 +69,7 @@ bitflags! {
     /// </g>
     /// </svg>
     /// </center>
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub struct Segments: u8 {
         /// A segment.
         const A = 0b01000000;


### PR DESCRIPTION
# Changes
Bumped all the dependency versions on the `Cargo.toml` to their latest, except `bitflags`, which was left at `1.3.2` otherwise it breaks with the following error:
```
error[E0204]: the trait `core::marker::Copy` cannot be implemented for this type
  --> /home/slushee/Documents/Projects/eg-seven-segment/src/digit.rs:10:24
   |
10 | #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
   |                        ^^^^
11 | pub struct Digit {
12 |     segments: Segments,
   |     ------------------ this field does not implement `core::marker::Copy`
   |
   = note: this error originates in the derive macro `Copy` (in Nightly builds, run with -Z macro-backtrace for more info)
```